### PR TITLE
chore: add bazel super formatter

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,22 +3,18 @@ bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 
 pip = use_extension("@rules_python//python:extensions.bzl", "pip")
-
 pip.parse(
     name = "pip",
     requirements_lock = "//:requirements_lock.txt",
 )
-
 use_repo(pip, "pip")
 
 # Specify python toolchain instead of using the host version
 python = use_extension("@rules_python//python:extensions.bzl", "python")
-
 python.toolchain(
     name = "python3_11",
     python_version = "3.11",
 )
-
 use_repo(python, "python3_11_toolchains")
 
 register_toolchains(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,6 @@
 bazel_dep(name = "rules_python", version = "0.20.0")
+bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
 
 pip = use_extension("@rules_python//python:extensions.bzl", "pip")
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ bazel run //app:calculator
 ```shell
 bazel test //...
 ```
+
+### Formatting
+
+**Note!** Formatting currently only works for BUILD and Markdown files.
+
+```shell
+bazel run @aspect_rules_format//format
+```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,30 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "aspect_rules_format",
+    sha256 = "c8d04f68082c0eeac2777e15f65048ece2f17d632023bdcc511602f8c5faf177",
+    strip_prefix = "bazel-super-formatter-2.0.0",
+    url = "https://github.com/aspect-build/bazel-super-formatter/archive/refs/tags/v2.0.0.tar.gz",
+)
+
+load("@aspect_rules_format//format:repositories.bzl", "rules_format_dependencies")
+
+rules_format_dependencies()
+
+# Register Node.js toolchain for bazel-super-formatter
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "node",
+    node_version = DEFAULT_NODE_VERSION,
+)
+
+load("@aspect_rules_format//format:dependencies.bzl", "parse_dependencies")
+
+parse_dependencies()
+
+# This should be done last in the WORKSPACE file to avoid getting the versions
+# of things from bazel-super-formatter instead of the intended versions.
+load("@aspect_rules_format//format:toolchains.bzl", "format_register_toolchains")
+
+format_register_toolchains()

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -1,16 +1,16 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 
 py_binary(
-  name = "calculator",
-  srcs = ["calculator.py"],
+    name = "calculator",
+    srcs = ["calculator.py"],
 )
 
 py_test(
-  name = "calculator_test",
-  srcs = ["calculator_test.py"],
-  deps = [
-    ":calculator",
-    "//tools/testrunner:testrunner",
-  ],
-  size = "small",
+    name = "calculator_test",
+    size = "small",
+    srcs = ["calculator_test.py"],
+    deps = [
+        ":calculator",
+        "//tools/testrunner",
+    ],
 )

--- a/tools/testrunner/BUILD.bazel
+++ b/tools/testrunner/BUILD.bazel
@@ -3,10 +3,10 @@ load("@pip//:requirements.bzl", "requirement")
 
 py_library(
     name = "testrunner",
+    testonly = True,
     srcs = ["testrunner.py"],
+    visibility = ["//visibility:public"],
     deps = [
         requirement("unittest-xml-reporting"),
     ],
-    visibility = ["//visibility:public"],
-    testonly = True,
 )


### PR DESCRIPTION
Add `bazel-super-formatter` and format the code.

Currently the formatting only works on BUILD and Markdown files, since
`bazel-super-formatter` doesn't support Bzlmod yet and I haven't found a
way to reuse the Python toolchain defined in `MODULE.bazel`.

Run the following command to format code:

```shell
bazel run @aspect_rules_format//format
```